### PR TITLE
fix: show result panel during lucky-one animation

### DIFF
--- a/src/lucky-one.ts
+++ b/src/lucky-one.ts
@@ -138,7 +138,7 @@ export class LuckyOne extends LitElement {
         </footer>
         <div class="winners-panel">
           <span ?hidden=${!this._raffleEnded}>🍀</span>
-          <result-panel ?hidden=${this._picked.length == 0} title=${this._lastPick} .result=${this._picked.slice(1)}></result-panel>
+          <result-panel ?hidden=${this._lastPick === "" && this._picked.length === 0} title=${this._lastPick} .result=${this._picked.slice(1)}></result-panel>
           <span ?hidden=${!this._raffleEnded}>🍀</span>
         </div>
       </div>


### PR DESCRIPTION
The result-panel was gated on `_picked.length === 0`, which kept it hidden
through the entire pick loop when "Remove pick" was off (the default).
The 15-iteration cycling that updates `_lastPick` was running, but the
panel stayed display:none until the loop finished, so the winner
appeared abruptly with no shuffle effect.

Gate visibility on `_lastPick` as well so the panel appears as soon as
the first iteration assigns a name, restoring the rapid-then-slowing
name cycle.

https://claude.ai/code/session_01MmrUJTde8zVR2GSWNj6eEN